### PR TITLE
Create ogsd.txt

### DIFF
--- a/lib/domains/net/ogsd.txt
+++ b/lib/domains/net/ogsd.txt
@@ -1,0 +1,1 @@
+Oak Grove School District, California, USA


### PR DESCRIPTION
Add Oak Grove School District, California, USA as "ogsd.net" domain.

This school district covers several schools, including Herman Intermediate School.